### PR TITLE
Updated level-browserify version

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "url": "git://github.com/mcollina/mqtt-level-store.git"
   },
   "dependencies": {
-    "level-browserify": "^0.18.1",
+    "level-browserify": "^1.0.1",
     "level-sublevel": "^6.4.6",
     "msgpack5": "2.0.0"
   },


### PR DESCRIPTION
`level-browserify@0.18.1` was using `leveldown@0.x.x` which does not work with `node@4`
