### PR TITLE
Added published order preserving functionality.

### DIFF
--- a/test.js
+++ b/test.js
@@ -7,7 +7,6 @@ var level = require('level-test')()
 var mqttLevelStore = require('./')
 var mqtt = require('mqtt')
 var Connection = require('mqtt-connection')
-var concat = require('concat-stream')
 var net = require('net')
 
 describe('mqtt level store', function () {
@@ -61,7 +60,14 @@ describe('mqtt.connect flow', function () {
     manager = mqttLevelStore({ level: level() })
   })
 
+  afterEach(function (done) {
+    server.close(function () {
+      done()
+    })
+  })
+
   it('should resend messages', function (done) {
+    var count = 0
     var client = mqtt.connect({
       port: 8883,
       incomingStore: manager.incoming,
@@ -74,9 +80,13 @@ describe('mqtt.connect flow', function () {
       serverClient.once('publish', function () {
         serverClient.stream.destroy()
 
-        manager.outgoing.createStream().pipe(concat(function (list) {
-          list.length.should.equal(1)
-        }))
+        manager.outgoing.createStream()
+          .on('data', function () {
+            ++count
+          })
+          .on('end', function () {
+            count.should.equal(1)
+          })
       })
 
       server.once('client', function (serverClient2) {
@@ -84,6 +94,43 @@ describe('mqtt.connect flow', function () {
           serverClient2.puback(packet)
           client.end()
           done()
+        })
+      })
+    })
+  })
+
+  it('should resend messages by published order', function (done) {
+    var serverCount = 0
+    var client = mqtt.connect({
+      port: 8883,
+      incomingStore: manager.incoming,
+      outgoingStore: manager.outgoing
+    })
+
+    client.nextId = 65535
+    client.publish('topic', 'payload1', {qos: 1})
+    client.publish('topic', 'payload2', {qos: 1})
+    client.publish('topic', 'payload3', {qos: 1})
+    server.once('client', function (serverClient) {
+      serverClient.on('publish', function () {
+        serverClient.stream.destroy()
+      })
+      server.once('client', function (serverClient2) {
+        serverClient2.on('publish', function (packet) {
+          serverClient2.puback(packet)
+          switch (serverCount++) {
+            case 0:
+              packet.payload.toString().should.equal('payload1')
+              break
+            case 1:
+              packet.payload.toString().should.equal('payload2')
+              break
+            case 2:
+              packet.payload.toString().should.equal('payload3')
+              client.end()
+              done()
+              break
+          }
         })
       })
     })


### PR DESCRIPTION
This pull request will add published order preserving functionality.

It requires MQTT.js update. See https://github.com/mqttjs/MQTT.js/pull/858.

Implementation note:

1. leved-db cannot keep insertion order.
2. I added the Date + counter to the value. The counter is to order multiple packets in the same millisecond.
3. When `createStream()` is called, first **read all records**(*1) from the level-db, then sort it by Date + counter, finally push the sorted data into my own stream.

*1 `level-db` provides only asynchronous interface to read records. So I paused my own stream until all asynchronous `level-db` read is finished. In order to do that, I use `pause()` and `resume()` methods.

Unfortunately, `pause()` and `resume()` does NOT work with `on('readable' ...)` but works well with `on('data' ...)`. So I sent the pull request to MQTT.js.

