### PR TITLE
Use callback style in `Manager.close()`.

### DIFF
--- a/mqtt-level-store.js
+++ b/mqtt-level-store.js
@@ -146,15 +146,41 @@ function Manager (path, options) {
 Manager.single = Store
 
 Manager.prototype.close = function (done) {
-  var that = this
-  this.incoming.close(function () {
-    that.outgoing.close(function () {
-      that._sublevel.close(function () {
-        that._level.close(function () {
-          done()
-        })
-      })
-    })
+  var incomingCloseCalled = false
+  var outgoingCloseCalled = false
+  var subLevelCloseCalled = false
+  var levelCloseCalled = false
+  var errors = {}
+
+  var tryAllClosed = function () {
+    if (incomingCloseCalled && outgoingCloseCalled && subLevelCloseCalled && levelCloseCalled) {
+      if (Object.keys(errors).length > 0) {
+        done(errors)
+      } else {
+        done()
+      }
+    }
+  }
+
+  this.incoming.close(function (err) {
+    incomingCloseCalled = true
+    if (err) errors['incoming'] = err
+    tryAllClosed()
+  })
+  this.outgoing.close(function (err) {
+    outgoingCloseCalled = true
+    if (err) errors['outgoing'] = err
+    tryAllClosed()
+  })
+  this._sublevel.close(function (err) {
+    subLevelCloseCalled = true
+    if (err) errors['sublevel'] = err
+    tryAllClosed()
+  })
+  this._level.close(function (err) {
+    levelCloseCalled = true
+    if (err) errors['level'] = err
+    tryAllClosed()
   })
 }
 

--- a/mqtt-level-store.js
+++ b/mqtt-level-store.js
@@ -152,10 +152,10 @@ Manager.prototype.close = function (done) {
   var levelCloseCalled = false
   var errors = {}
 
-  var tryAllClosed = function () {
+  function tryAllClosed () {
     if (incomingCloseCalled && outgoingCloseCalled && subLevelCloseCalled && levelCloseCalled) {
       if (Object.keys(errors).length > 0) {
-        done(errors)
+        done(new Error(JSON.stringify(errors)))
       } else {
         done()
       }
@@ -164,22 +164,22 @@ Manager.prototype.close = function (done) {
 
   this.incoming.close(function (err) {
     incomingCloseCalled = true
-    if (err) errors['incoming'] = err
+    if (err) errors['incoming'] = err.message
     tryAllClosed()
   })
   this.outgoing.close(function (err) {
     outgoingCloseCalled = true
-    if (err) errors['outgoing'] = err
+    if (err) errors['outgoing'] = err.message
     tryAllClosed()
   })
   this._sublevel.close(function (err) {
     subLevelCloseCalled = true
-    if (err) errors['sublevel'] = err
+    if (err) errors['sublevel'] = err.message
     tryAllClosed()
   })
   this._level.close(function (err) {
     levelCloseCalled = true
-    if (err) errors['level'] = err
+    if (err) errors['level'] = err.message
     tryAllClosed()
   })
 }

--- a/mqtt-level-store.js
+++ b/mqtt-level-store.js
@@ -146,10 +146,16 @@ function Manager (path, options) {
 Manager.single = Store
 
 Manager.prototype.close = function (done) {
-  this.incoming.close()
-  this.outgoing.close()
-  this._sublevel.close()
-  this._level.close(done)
+  var that = this
+  this.incoming.close(function () {
+    that.outgoing.close(function () {
+      that._sublevel.close(function () {
+        that._level.close(function () {
+          done()
+        })
+      })
+    })
+  })
 }
 
 module.exports = Manager

--- a/test.js
+++ b/test.js
@@ -55,19 +55,14 @@ describe('mqtt level store manager close', function () {
     var subLevelCloseSaved = errorManager._sublevel.close
     var levelCloseSaved = errorManager._level.close
 
-    var closeReturnError = function (cb, suffix) {
-      var f = function (err) { cb(err) }
-      f('error_' + suffix)
-    }
-
-    errorManager.incoming.close = function (cb) { closeReturnError(cb, 'i') }
-    errorManager.outgoing.close = function (cb) { closeReturnError(cb, 'o') }
-    errorManager._sublevel.close = function (cb) { closeReturnError(cb, 's') }
-    errorManager._level.close = function (cb) { closeReturnError(cb, 'l') }
+    errorManager.incoming.close = function (cb) { cb(new Error('error_i')) }
+    errorManager.outgoing.close = function (cb) { cb(new Error('error_o')) }
+    errorManager._sublevel.close = function (cb) { cb(new Error('error_s')) }
+    errorManager._level.close = function (cb) { cb(new Error('error_l')) }
 
     var expected = {'incoming': 'error_i', 'outgoing': 'error_o', 'sublevel': 'error_s', 'level': 'error_l'}
     errorManager.close(function (err) {
-      should.deepEqual(err, expected)
+      should.deepEqual(JSON.parse(err.message), expected)
       errorManager.incoming.close = incomingCloseSaved
       errorManager.outgoing.close = outgoingCloseSaved
       errorManager._sublevel.close = subLevelCloseSaved

--- a/test.js
+++ b/test.js
@@ -9,6 +9,7 @@ var mqtt = require('mqtt')
 var Connection = require('mqtt-connection')
 var concat = require('concat-stream')
 var net = require('net')
+var should = require('should')
 
 describe('mqtt level store', function () {
   abstractTest(function (done) {
@@ -36,6 +37,45 @@ describe('mqtt level store manager', function () {
   describe('outgoing', function () {
     abstractTest(function (done) {
       done(null, manager.outgoing)
+    })
+  })
+})
+
+describe('mqtt level store manager close', function () {
+  it('should finish successfully.', function (done) {
+    var manager = mqttLevelStore({ level: level() })
+    manager.close(done)
+  })
+
+  it('should return errors when failed to close.', function (done) {
+    var errorManager = mqttLevelStore({ level: level() })
+
+    var incomingCloseSaved = errorManager.incoming.close
+    var outgoingCloseSaved = errorManager.outgoing.close
+    var subLevelCloseSaved = errorManager._sublevel.close
+    var levelCloseSaved = errorManager._level.close
+
+    var closeReturnError = function (cb, suffix) {
+      var f = function (err) { cb(err) }
+      f('error_' + suffix)
+    }
+
+    errorManager.incoming.close = function (cb) { closeReturnError(cb, 'i') }
+    errorManager.outgoing.close = function (cb) { closeReturnError(cb, 'o') }
+    errorManager._sublevel.close = function (cb) { closeReturnError(cb, 's') }
+    errorManager._level.close = function (cb) { closeReturnError(cb, 'l') }
+
+    var expected = {'incoming': 'error_i', 'outgoing': 'error_o', 'sublevel': 'error_s', 'level': 'error_l'}
+    errorManager.close(function (err) {
+      should.deepEqual(err, expected)
+      errorManager.incoming.close = incomingCloseSaved
+      errorManager.outgoing.close = outgoingCloseSaved
+      errorManager._sublevel.close = subLevelCloseSaved
+      errorManager._level.close = levelCloseSaved
+      errorManager.close(function (err) {
+        should.not.exist(err)
+        done()
+      })
     })
   })
 })


### PR DESCRIPTION
Call `close()` method of each resources by callback style because `close()` method of `incoming`, `outgoing`, `_sublevel`, `_level` can take callback function as a parameter.

Outcome:
This fix guarantees the sequence of resource closing.