### PR TITLE
make store data overwritable

### DIFF
--- a/mqtt-level-store.js
+++ b/mqtt-level-store.js
@@ -58,7 +58,6 @@ Store.prototype.put = function (packet, cb) {
           that._levelOpts,
           function (err, _packet) {
             if (err) return cb(err)
-            if (packet.cmd === _packet.cmd) return cb()
             that._level.put('packet-by-date~' + _date + '~' + packet.messageId, packet, that._levelOpts, cb)
           })
       }

--- a/test.js
+++ b/test.js
@@ -155,7 +155,7 @@ describe('mqtt.connect flow', function () {
 // Topic Aliased packet is TopicName: '', Property TopicAlias: 123
 // Overwrite
 // TopicName: '' to 'topic1', remove Property TopicAlias
-describe.only('overwrite', function () {
+describe('overwrite', function () {
   var manager
 
   beforeEach(function () {


### PR DESCRIPTION

Packets cannot be overwritten by PUT function.
I fixed the put function.

Mqtt v5 has Topics Alias. 
Topic Alias ​​may omit the topic name.
The topic name cannot be resolved when reconnecting and resending the omitted packet from the store.
Therefore, I want to overwrite and update the topic name part that was omitted after storing it in the store.