### PR TITLE
Replaced level-sublevel with subleveldown

### DIFF
--- a/abstract_store.js
+++ b/abstract_store.js
@@ -1,0 +1,138 @@
+'use strict'
+
+/* eslint-env mocha */
+
+// Borrowed from MQTT.js test files
+require('should')
+
+module.exports = function abstractStoreTest (build) {
+  let store
+
+  beforeEach(function (done) {
+    build(function (err, _store) {
+      store = _store
+      done(err)
+    })
+  })
+
+  afterEach(function (done) {
+    store.close(done)
+  })
+
+  it('should put and stream in-flight packets', function (done) {
+    const packet = {
+      topic: 'hello',
+      payload: 'world',
+      qos: 1,
+      messageId: 42
+    }
+
+    store.put(packet, function () {
+      store
+        .createStream()
+        .on('data', function (data) {
+          data.should.eql(packet)
+          done()
+        })
+    })
+  })
+
+  it('should support destroying the stream', function (done) {
+    const packet = {
+      topic: 'hello',
+      payload: 'world',
+      qos: 1,
+      messageId: 42
+    }
+
+    store.put(packet, function () {
+      const stream = store.createStream()
+      stream.on('close', done)
+      stream.destroy()
+    })
+  })
+
+  it('should add and del in-flight packets', function (done) {
+    const packet = {
+      topic: 'hello',
+      payload: 'world',
+      qos: 1,
+      messageId: 42
+    }
+
+    store.put(packet, function () {
+      store.del(packet, function () {
+        store
+          .createStream()
+          .on('data', function () {
+            done(new Error('this should never happen'))
+          })
+          .on('end', done)
+      })
+    })
+  })
+
+  it('should replace a packet when doing put with the same messageId', function (done) {
+    const packet1 = {
+      cmd: 'publish', // added
+      topic: 'hello',
+      payload: 'world',
+      qos: 2,
+      messageId: 42
+    }
+    const packet2 = {
+      cmd: 'pubrel', // added
+      qos: 2,
+      messageId: 42
+    }
+
+    store.put(packet1, function () {
+      store.put(packet2, function () {
+        store
+          .createStream()
+          .on('data', function (data) {
+            data.should.eql(packet2)
+            done()
+          })
+      })
+    })
+  })
+
+  it('should return the original packet on del', function (done) {
+    const packet = {
+      topic: 'hello',
+      payload: 'world',
+      qos: 1,
+      messageId: 42
+    }
+
+    store.put(packet, function () {
+      store.del({ messageId: 42 }, function (err, deleted) {
+        if (err) {
+          throw err
+        }
+        deleted.should.eql(packet)
+        done()
+      })
+    })
+  })
+
+  it('should get a packet with the same messageId', function (done) {
+    const packet = {
+      topic: 'hello',
+      payload: 'world',
+      qos: 1,
+      messageId: 42
+    }
+
+    store.put(packet, function () {
+      store.get({ messageId: 42 }, function (err, fromDb) {
+        if (err) {
+          throw err
+        }
+        fromDb.should.eql(packet)
+        done()
+      })
+    })
+  })
+}

--- a/example.js
+++ b/example.js
@@ -1,11 +1,9 @@
 'use strict'
 
-var mqtt = require('mqtt')
-var levelStore = require('./')
-var manager = levelStore('db')
-var client
-
-client = mqtt.connect({
+const mqtt = require('mqtt')
+const levelStore = require('./')
+const manager = levelStore('db')
+const client = mqtt.connect({
   port: 1883,
   incomingStore: manager.incoming,
   outgoingStore: manager.outgoing

--- a/package.json
+++ b/package.json
@@ -20,19 +20,19 @@
     "url": "git://github.com/mcollina/mqtt-level-store.git"
   },
   "dependencies": {
-    "level": "^5.0.0",
-    "level-sublevel": "^6.6.1",
-    "msgpack5": "^4.0.0"
+    "level": "^7.0.0",
+    "msgpack5": "^5.3.2",
+    "subleveldown": "^5.0.1"
   },
   "devDependencies": {
     "concat-stream": "^2.0.0",
-    "level-test": "^7.0.0",
-    "levelup": "^4.0.1",
-    "mocha": "^6.0.0",
-    "mqtt": "^3.0.0",
-    "mqtt-connection": "^4.0.0",
+    "level-test": "^9.0.0",
+    "levelup": "^5.0.1",
+    "mocha": "^9.1.0",
+    "mqtt": "^4.2.8",
+    "mqtt-connection": "^4.1.0",
     "pre-commit": "^1.2.2",
-    "should": "^13.0.0",
-    "standard": "^12.0.1"
+    "should": "^13.2.3",
+    "standard": "^16.0.3"
   }
 }


### PR DESCRIPTION
Fixes issue with level-sublevel which causes 'end' event on ReadStream
to be fired prematurely. This caused a race condition in MQTT.js.

Upgraded packages and added abstract_store.js from MQTT.js upstream.

Fixes #21